### PR TITLE
fix:Could not find the requested service firewalld

### DIFF
--- a/ansible/awx-rpm/tasks/main.yml
+++ b/ansible/awx-rpm/tasks/main.yml
@@ -35,11 +35,15 @@
     persistent: true
   become: true
 
+- name: Populate service facts
+  ansible.builtin.service_facts:
+
 - name: Disable Firewalld, TODO, Re-enable
   ansible.builtin.service:
     name: firewalld
     state: stopped
     enabled: false
+  when: '"firewalld" in ansible_facts.services'
 
 - name: Set nis_enabled flag on and keep it persistent across reboots
   ansible.posix.seboolean:


### PR DESCRIPTION
Not all RHEL derivatives have firewalld installed, e.g. CentOS 9 AWS
Cloud Images come without firewalld installed.

Only disable firewalld service if it is actually installed.
