### PR TITLE
    fix: executable subscription-manager was not found

### DIFF
--- a/ansible/awx-rpm/tasks/main.yml
+++ b/ansible/awx-rpm/tasks/main.yml
@@ -80,7 +80,7 @@
   community.general.rhsm_repository:
     name: codeready-builder-for-rhel-9-x86_64-rpms
   become: true
-  when: ansible_facts['os_family'] == 'RedHat'
+  when: ansible_facts['distribution'] == 'RedHat'
 
 - name: Install AWX-RPM
   ansible.builtin.dnf:


### PR DESCRIPTION

    All RHEL derivatives are of the 'RedHat' OS Family, but only the RedHat
    distribution uses RHSM, other derivates do not.

