### PR TITLE
fix: systemd unit dependencies

### DIFF
--- a/ansible/awx-rpm/tasks/main.yml
+++ b/ansible/awx-rpm/tasks/main.yml
@@ -167,14 +167,15 @@
     state: restarted
     enabled: true
   with_items:
-    - redis
-    - nginx
-    - awx-daphne
-    - awx-receiver
-    - awx-receptor
-    - awx-web
-    - awx-dispatcher
-    - awx-receptor-hop
-    - awx-receptor-worker
-    - awx-wsbroadcast
+    - redis.service
+    - nginx.service
+    - awx.target
+    - awx-daphne.service
+    - awx-receiver.service
+    - awx-receptor.service
+    - awx-web.service
+    - awx-dispatcher.service
+    - awx-receptor-hop.service
+    - awx-receptor-worker.service
+    - awx-wsbroadcast.service
   become: true

--- a/awx-rpm/awx-daphne.service-21.11.0
+++ b/awx-rpm/awx-daphne.service-21.11.0
@@ -1,7 +1,6 @@
 [Unit]
 Description=AWX daphne service
-PartOf=awx.service
-After=awx.service
+PartOf=awx.target
 
 [Service]
 User=awx
@@ -14,4 +13,4 @@ Restart=on-failure
 RestartSec=2s
 
 [Install]
-WantedBy=awx.service
+WantedBy=awx.target

--- a/awx-rpm/awx-dispatcher.service-21.11.0
+++ b/awx-rpm/awx-dispatcher.service-21.11.0
@@ -1,8 +1,6 @@
 [Unit]
 Description=AWX Dispatcher
-After=syslog.target network.target
-PartOf=awx.service
-After=awx.service
+PartOf=awx.target
 
 [Service]
 User=awx
@@ -15,4 +13,4 @@ Restart=on-failure
 RestartSec=2s
 
 [Install]
-WantedBy=awx.service
+WantedBy=awx.target

--- a/awx-rpm/awx-receiver.service-21.11.0
+++ b/awx-rpm/awx-receiver.service-21.11.0
@@ -1,8 +1,6 @@
 [Unit]
 Description=AWX receiver service
-After=syslog.target network.target
-PartOf=awx.service
-After=awx.service
+PartOf=awx.target
 
 [Service]
 User=awx
@@ -15,4 +13,4 @@ Restart=on-failure
 RestartSec=2s
 
 [Install]
-WantedBy=awx.service
+WantedBy=awx.target

--- a/awx-rpm/awx-receptor-hop.service-21.11.0
+++ b/awx-rpm/awx-receptor-hop.service-21.11.0
@@ -1,8 +1,6 @@
 [Unit]
 Description=AWX receptor hop service
-After=syslog.target network.target
-PartOf=awx.service
-After=awx.service
+PartOf=awx.target
 
 [Service]
 User=awx
@@ -13,4 +11,4 @@ Restart=on-failure
 RestartSec=2s
 
 [Install]
-WantedBy=awx.service
+WantedBy=awx.target

--- a/awx-rpm/awx-receptor-worker.service-21.11.0
+++ b/awx-rpm/awx-receptor-worker.service-21.11.0
@@ -1,8 +1,6 @@
 [Unit]
 Description=AWX receptor worker service
-After=syslog.target network.target
-PartOf=awx.service
-After=awx.service
+PartOf=awx.target
 
 [Service]
 User=awx
@@ -13,4 +11,4 @@ Restart=on-failure
 RestartSec=2s
 
 [Install]
-WantedBy=awx.service
+WantedBy=awx.target

--- a/awx-rpm/awx-receptor.service-21.11.0
+++ b/awx-rpm/awx-receptor.service-21.11.0
@@ -1,8 +1,6 @@
 [Unit]
 Description=AWX receptor service
-After=syslog.target network.target
-PartOf=awx.service
-After=awx.service
+PartOf=awx.target
 
 [Service]
 User=awx
@@ -13,4 +11,4 @@ Restart=on-failure
 RestartSec=2s
 
 [Install]
-WantedBy=awx.service
+WantedBy=awx.target

--- a/awx-rpm/awx-web.service-21.11.0
+++ b/awx-rpm/awx-web.service-21.11.0
@@ -1,8 +1,6 @@
 [Unit]
 Description=AWX web service
-After=syslog.target network.target
-PartOf=awx.service
-After=awx.service
+PartOf=awx.target
 
 [Service]
 EnvironmentFile=-/etc/sysconfig/awx
@@ -25,8 +23,10 @@ ExecStart=/usr/bin/uwsgi -b 32768 \
              --lazy-apps \
              --logformat "%(addr) %(method) %(uri) - %(proto) %(status)" \
              --logto=/var/log/tower/web.log
+KillSignal=SIGQUIT
+Type=notify
 Restart=on-failure
 RestartSec=2s
 
 [Install]
-WantedBy=awx.service
+WantedBy=awx.target

--- a/awx-rpm/awx-wsbroadcast.service-21.11.0
+++ b/awx-rpm/awx-wsbroadcast.service-21.11.0
@@ -1,8 +1,6 @@
 [Unit]
 Description=AWX channels worker service
-After=syslog.target network.target
-PartOf=awx.service
-After=awx.service
+PartOf=awx.target
 
 [Service]
 User=awx
@@ -15,4 +13,4 @@ Restart=on-failure
 RestartSec=2s
 
 [Install]
-WantedBy=awx.service
+WantedBy=awx.target

--- a/awx-rpm/awx.target-21.11.0
+++ b/awx-rpm/awx.target-21.11.0
@@ -1,0 +1,12 @@
+[Unit]
+Description=AWX
+After=syslog.target network.target
+After=postgresql.service
+After=nginx.service
+After=redis.service
+Wants=postgresql.service
+Wants=nginx.service
+Wants=redis.service
+
+[Install]
+WantedBy=multi-user.target

--- a/awx-rpm/awx.target-21.11.0
+++ b/awx-rpm/awx.target-21.11.0
@@ -4,9 +4,9 @@ After=syslog.target network.target
 After=postgresql.service
 After=nginx.service
 After=redis.service
-Wants=postgresql.service
-Wants=nginx.service
-Wants=redis.service
+Requires=postgresql.service
+Requires=nginx.service
+Requires=redis.service
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
I found two issues in the current version of the systemd units:

* units are not started correctly during boot
* awx-web hangs forever(?) during shutdown

I reorganized the units into an `awx.target` which needs to be enabled in the Ansible role.

The target file needs to be included into the `spec` file(s). I do not really understand how they are used and left it out in this pull request.